### PR TITLE
Lv 3. 테스트코드 연습

### DIFF
--- a/src/main/java/org/example/expert/config/PasswordEncoder.java
+++ b/src/main/java/org/example/expert/config/PasswordEncoder.java
@@ -10,6 +10,7 @@ public class PasswordEncoder {
         return BCrypt.withDefaults().hashToString(BCrypt.MIN_COST, rawPassword.toCharArray());
     }
 
+    // 첫번째 인자를 BCrypt 해싱 알고리즘을 사용하여 암호화한 후, 두번째 인자(해시값)과 비교하는 메소드
     public boolean matches(String rawPassword, String encodedPassword) {
         BCrypt.Result result = BCrypt.verifyer().verify(rawPassword.toCharArray(), encodedPassword);
         return result.verified;

--- a/src/main/java/org/example/expert/domain/comment/service/CommentService.java
+++ b/src/main/java/org/example/expert/domain/comment/service/CommentService.java
@@ -30,7 +30,7 @@ public class CommentService {
         User user = User.fromAuthUser(authUser);
         Todo todo = todoRepository.findById(todoId).orElseThrow(() ->
                 new InvalidRequestException("Todo not found"));
-
+                // InvalidRequestException 발생 (Server X)
         Comment newComment = new Comment(
                 commentSaveRequest.getContents(),
                 user,

--- a/src/main/java/org/example/expert/domain/manager/service/ManagerService.java
+++ b/src/main/java/org/example/expert/domain/manager/service/ManagerService.java
@@ -34,7 +34,10 @@ public class ManagerService {
         User user = User.fromAuthUser(authUser);
         Todo todo = todoRepository.findById(todoId)
                 .orElseThrow(() -> new InvalidRequestException("Todo not found"));
-
+        // todo의 user가 null인 경우 InvalidRequestException을 발생시킨다 (메세지는 deleteManager와 통일시킨다)
+        if(todo.getUser() == null){
+            throw new InvalidRequestException("해당 일정을 만든 유저가 유효하지 않습니다.");
+        }
         if (!ObjectUtils.nullSafeEquals(user.getId(), todo.getUser().getId())) {
             throw new InvalidRequestException("담당자를 등록하려고 하는 유저가 일정을 만든 유저가 유효하지 않습니다.");
         }

--- a/src/main/java/org/example/expert/domain/manager/service/ManagerService.java
+++ b/src/main/java/org/example/expert/domain/manager/service/ManagerService.java
@@ -57,6 +57,7 @@ public class ManagerService {
 
     @Transactional(readOnly = true)
     public List<ManagerResponse> getManagers(long todoId) {
+        // todoId가 존재하는지 확인 -> 찾지 못하는 경우 IRE 예외 발생
         Todo todo = todoRepository.findById(todoId)
                 .orElseThrow(() -> new InvalidRequestException("Todo not found"));
 

--- a/src/test/java/org/example/expert/config/PasswordEncoderTest.java
+++ b/src/test/java/org/example/expert/config/PasswordEncoderTest.java
@@ -20,7 +20,7 @@ class PasswordEncoderTest {
         String encodedPassword = passwordEncoder.encode(rawPassword);
 
         // when
-        boolean matches = passwordEncoder.matches(encodedPassword, rawPassword);
+        boolean matches = passwordEncoder.matches(rawPassword, encodedPassword);
         // passwordEncoder.matches()메서드: 첫번째 인자를 BCrypt 해싱 알고리즘을 사용하여 암호화한 후, 두번째 인자(해시값)과 비교하는 메소드
         // public boolean matches(String rawPassword, String encodedPassword)
         // [문제] 첫 번째 인자에 암호화되지 않은 패스워드, 두 번째 인자에 암호화된 패스워드를 기입헤야 함 (뒤바뀜)

--- a/src/test/java/org/example/expert/config/PasswordEncoderTest.java
+++ b/src/test/java/org/example/expert/config/PasswordEncoderTest.java
@@ -21,6 +21,9 @@ class PasswordEncoderTest {
 
         // when
         boolean matches = passwordEncoder.matches(encodedPassword, rawPassword);
+        // passwordEncoder.matches()메서드: 첫번째 인자를 BCrypt 해싱 알고리즘을 사용하여 암호화한 후, 두번째 인자(해시값)과 비교하는 메소드
+        // public boolean matches(String rawPassword, String encodedPassword)
+        // [문제] 첫 번째 인자에 암호화되지 않은 패스워드, 두 번째 인자에 암호화된 패스워드를 기입헤야 함 (뒤바뀜)
 
         // then
         assertTrue(matches);

--- a/src/test/java/org/example/expert/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/org/example/expert/domain/comment/service/CommentServiceTest.java
@@ -5,7 +5,7 @@ import org.example.expert.domain.comment.dto.response.CommentSaveResponse;
 import org.example.expert.domain.comment.entity.Comment;
 import org.example.expert.domain.comment.repository.CommentRepository;
 import org.example.expert.domain.common.dto.AuthUser;
-import org.example.expert.domain.common.exception.ServerException;
+import org.example.expert.domain.common.exception.InvalidRequestException;
 import org.example.expert.domain.todo.entity.Todo;
 import org.example.expert.domain.todo.repository.TodoRepository;
 import org.example.expert.domain.user.entity.User;
@@ -43,7 +43,7 @@ class CommentServiceTest {
         given(todoRepository.findById(anyLong())).willReturn(Optional.empty());
 
         // when
-        ServerException exception = assertThrows(ServerException.class, () -> {
+        InvalidRequestException exception = assertThrows(InvalidRequestException.class, () -> {
             commentService.saveComment(authUser, todoId, request);
         });
 

--- a/src/test/java/org/example/expert/domain/manager/service/ManagerServiceTest.java
+++ b/src/test/java/org/example/expert/domain/manager/service/ManagerServiceTest.java
@@ -39,14 +39,15 @@ class ManagerServiceTest {
     private ManagerService managerService;
 
     @Test
-    public void manager_목록_조회_시_Todo가_없다면_NPE_에러를_던진다() {
+    public void manager_목록_조회_시_Todo가_없다면_IRE_에러를_던진다() {   // [이름 오류] NullPointerException을 던지지 않는다 -> InvalidRequestException
         // given
         long todoId = 1L;
-        given(todoRepository.findById(todoId)).willReturn(Optional.empty());
+        given(todoRepository.findById(todoId)).willReturn(Optional.empty());    // Todo가 없는 상황 가정
 
         // when & then
-        InvalidRequestException exception = assertThrows(InvalidRequestException.class, () -> managerService.getManagers(todoId));
-        assertEquals("Manager not found", exception.getMessage());
+        InvalidRequestException exception = assertThrows(InvalidRequestException.class,
+                () -> managerService.getManagers(todoId));
+        assertEquals("Todo not found", exception.getMessage());          // Todo를 조회 못 하는 상황임을 인식해야 함
     }
 
     @Test

--- a/src/test/java/org/example/expert/domain/manager/service/ManagerServiceTest.java
+++ b/src/test/java/org/example/expert/domain/manager/service/ManagerServiceTest.java
@@ -69,7 +69,7 @@ class ManagerServiceTest {
             managerService.saveManager(authUser, todoId, managerSaveRequest)
         );
 
-        assertEquals("담당자를 등록하려고 하는 유저가 일정을 만든 유저가 유효하지 않습니다.", exception.getMessage());
+        assertEquals("해당 일정을 만든 유저가 유효하지 않습니다.", exception.getMessage());
     }
 
     @Test // 테스트코드 샘플


### PR DESCRIPTION
# Lv 3. 테스트코드 연습
## 1. 예상대로 성공하는지에 대한 케이스

- **문제** : passwordEncoder.matches(암호화 안 된 패스워드, 암호화 된 패스워드) 형태인데, 인자값을 잘못 넣었다.
  - `boolean matches = passwordEncoder.matches(encodedPassword, rawPassword);`
- **해결** : 메소드 정의에 맞게 인자값을 제대로 넣는다(두 인자를 바꾸면 됨)
  - `boolean matches = passwordEncoder.matches(rawPassword, encodedPassword);`

## 2 - 케이스 1. 예상대로 예외처리 하는지에 대한 케이스
- 파일 위치 `‎src/main/java/org/example/expert/domain/manager/service` 의 `ManagerServiceTest` class 의 `getManagers` method
  ```
  public List<ManagerResponse> getManagers(long todoId) {
    Todo todo = todoRepository.findById(todoId)
      .orElseThrow(() -> new InvalidRequestException("Todo not found"));
  ```
  - getManager 는 `InvalidRequestException` 예외를 발생시키고 `"Todo not found"` 메세지를 만든다.

- 파일 위치 `‎src/test/java/org/example/expert/domain/manager/service` 의 `ManagerService` class
  - **문제**: 테스트 코드의 이름이 의미적으로 맞지 않고, 비교하려는 에러 메세지를 틀리게 작성하였다. 
    - `public void manager_목록_조회_시_Todo가_없다면_NPE_에러를_던진다()` [이름오류] 해당 메서드는 NPE가 아니라 IRE 에러를 던짐
    - `assertEquals("Manager not found", exception.getMessage());` [코드오류] 발생하는 에러 메세지는 Manager not found가 아니라 Todo not found
  - **해결**: 테스트 코드의 이름과 비교하려는 에러 메세지를 getManager의 예외타입과 에러메세지로 작성한다. 
    - `public void manager_목록_조회_시_Todo가_없다면_IRE_에러를_던진다()`
    - `assertEquals("Todo not found", exception.getMessage());`

## 2 - 케이스 2. 예상대로 예외처리 하는지에 대한 케이스
- 파일 위치 `‎‎src/main/java/org/example/expert/domain/comment/service` 의 `CommentService` class 의 `saveComment` method
  ```
  public CommentSaveResponse saveComment(AuthUser authUser, long todoId, CommentSaveRequest commentSaveRequest) {
    User user = User.fromAuthUser(authUser);
    Todo todo = todoRepository.findById(todoId).orElseThrow(() ->
      new InvalidRequestException("Todo not found"));
  ... }
  ```
  - saveComment 는 `InvalidRequestException` 예외를 발생시키고 `"Todo not found"` 메세지를 만든다.  
  
- 파일 위치 `‎src/test/java/org/example/expert/domain/comment/service` 의 `CommentServiceTest` class
  - **문제**: 테스트 코드는 `saveComment()` 에서 `ServerException`이 발생할 때를 다루는데, 실상 `saveComment()`에서는 해당 예외가 발생하지 않음
    - `import org.example.expert.domain.common.exception.ServerException;`
    -  `ServerException exception = assertThrows(ServerException.class, () -> {`
  - **해결**: `saveComment()`에서 발생하는 예외를 테스트 코드가 다루도록 수정한다.
    - `import org.example.expert.domain.common.exception.InvalidRequestException;`
    -  `InvalidRequestException exception = assertThrows(InvalidRequestException.class, () -> {`

## 2 - 케이스 3. 예상대로 예외처리 하는지에 대한 케이스

- 파일위치 `src/main/java/org/example/expert/domain/manager/service` 의 `ManagerService` class의 `saveManager` method 
  ```
  @Transactional
  public ManagerSaveResponse saveManager(AuthUser authUser, long todoId, ManagerSaveRequest managerSaveRequest) {
    User user = User.fromAuthUser(authUser);
    Todo todo = todoRepository.findById(todoId)
      .orElseThrow(() -> new InvalidRequestException("Todo not found"));
  ...
  ```

- **방향성** todo의 user가 null인 경우 InvalidRequestException을 발생시키는 코드를 추가한다.
  ```
  @Transactional
  public ManagerSaveResponse saveManager(AuthUser authUser, long todoId, ManagerSaveRequest managerSaveRequest) {
    User user = User.fromAuthUser(authUser);
    Todo todo = todoRepository.findById(todoId)
      .orElseThrow(() -> new InvalidRequestException("Todo not found"));
    if(todo.getUser() == null){
      throw new InvalidRequestException("해당 일정을 만든 유저가 유효하지 않습니다.");
    }
  ...
  ```

- **추가 변경사항** 비교할 에러메세지를 수정한다
  - 파일 위치 `‎‎src/test/java/org/example/expert/domain/manager/service` 의 `ManagerServiceTest` class
  - 수정 전 `assertEquals("담당자를 등록하려고 하는 유저가 일정을 만든 유저가 유효하지 않습니다.", exception.getMessage());`
  - 수정 후 `assertEquals("해당 일정을 만든 유저가 유효하지 않습니다.", exception.getMessage());`